### PR TITLE
Changed elif condition in _token creation

### DIFF
--- a/django_tinkoff_merchant/services.py
+++ b/django_tinkoff_merchant/services.py
@@ -62,7 +62,7 @@ class MerchantAPI(object):
                 continue
             if isinstance(value_token, bool):
                 base.append([name_token, str(value_token).lower()])
-            elif not isinstance(value_token, list) or not isinstance(value_token, dict):
+            elif not isinstance(value_token, list) and not isinstance(value_token, dict):
                 base.append([name_token, value_token])
 
         base.sort(key=lambda i: i[0])


### PR DESCRIPTION
In python if conditions are lazy, so the previous version (with OR) did not working as supposed, 

e.g. having  initial data = {'Success': True, 'TerminalKey': '1525120204909DEMO', 'Status': 'CONFIRMED','ExpDate': '1122','CardId': 484209, 'Pan': '430000******0777', 'Amount': 100,'PaymentId': 22461408,'OrderId': 1, 'Token': '', 'ErrorCode': '0','Receipt':[1,2,3],'Items':{'a':1}}

will result in "10048420901122{'a': 1}1430000******077722461408[1, 2, 3]CONFIRMEDtrue1525120204909DEMO"

instead of '100484209011221430000******077722461408CONFIRMEDtrue1525120204909DEMO'